### PR TITLE
added option to disable block interactions (for notebot chamber)

### DIFF
--- a/v1_17/src/main/java/me/aleksilassila/litematica/printer/v1_17/LitematicaMixinMod.java
+++ b/v1_17/src/main/java/me/aleksilassila/litematica/printer/v1_17/LitematicaMixinMod.java
@@ -26,6 +26,7 @@ public class LitematicaMixinMod implements ModInitializer {
     public static final ConfigBoolean PRINT_MODE = new ConfigBoolean("printingMode", false, "Autobuild / print loaded selection.\nBe aware that some servers and anticheat plugins do not allow printing.");
     public static final ConfigBoolean REPLACE_FLUIDS_SOURCE_BLOCKS = new ConfigBoolean("replaceFluidSourceBlocks", true, "Whether or not fluid source blocks should be replaced by the printer.");
     public static final ConfigBoolean STRIP_LOGS = new ConfigBoolean("stripLogs", true, "Whether or not the printer should use normal logs if stripped\nversions are not available and then strip them with an axe.");
+    public static final ConfigBoolean INTERACT_BLOCKS = new ConfigBoolean("interactBlocks", true, "Whether or not the printer should set block states.");
 
     public static ImmutableList<IConfigBase> getConfigList() {
         List<IConfigBase> list = new java.util.ArrayList<>(Configs.Generic.OPTIONS);
@@ -35,6 +36,7 @@ public class LitematicaMixinMod implements ModInitializer {
 //        list.add(PRINT_IN_AIR);
         list.add(REPLACE_FLUIDS_SOURCE_BLOCKS);
         list.add(STRIP_LOGS);
+        list.add(INTERACT_BLOCKS);
 
         return ImmutableList.copyOf(list);
     }

--- a/v1_17/src/main/java/me/aleksilassila/litematica/printer/v1_17/Printer.java
+++ b/v1_17/src/main/java/me/aleksilassila/litematica/printer/v1_17/Printer.java
@@ -57,7 +57,7 @@ public class Printer {
             boolean isCurrentlyLooking = ((BlockHitResult) player.raycast(20, 1, false)).getBlockPos().equals(position);
 
             for (Guide guide : guides) {
-                if (guide.canExecute(player)) {
+                if (guide.canExecute(player) && LitematicaMixinMod.INTERACT_BLOCKS.getBooleanValue()) {
                     System.out.println("Executing " + guide + " for " + state);
                     List<Action> actions = guide.execute(player);
                     actionHandler.addActions(actions.toArray(Action[]::new));

--- a/v1_18/src/main/java/me/aleksilassila/litematica/printer/v1_18/LitematicaMixinMod.java
+++ b/v1_18/src/main/java/me/aleksilassila/litematica/printer/v1_18/LitematicaMixinMod.java
@@ -26,6 +26,7 @@ public class LitematicaMixinMod implements ModInitializer {
     public static final ConfigBoolean PRINT_MODE = new ConfigBoolean("printingMode", false, "Autobuild / print loaded selection.\nBe aware that some servers and anticheat plugins do not allow printing.");
     public static final ConfigBoolean REPLACE_FLUIDS_SOURCE_BLOCKS = new ConfigBoolean("replaceFluidSourceBlocks", true, "Whether or not fluid source blocks should be replaced by the printer.");
     public static final ConfigBoolean STRIP_LOGS = new ConfigBoolean("stripLogs", true, "Whether or not the printer should use normal logs if stripped\nversions are not available and then strip them with an axe.");
+    public static final ConfigBoolean INTERACT_BLOCKS = new ConfigBoolean("interactBlocks", true, "Whether or not the printer should set block states.");
 
     public static ImmutableList<IConfigBase> getConfigList() {
         List<IConfigBase> list = new java.util.ArrayList<>(Configs.Generic.OPTIONS);
@@ -35,6 +36,7 @@ public class LitematicaMixinMod implements ModInitializer {
 //        list.add(PRINT_IN_AIR);
         list.add(REPLACE_FLUIDS_SOURCE_BLOCKS);
         list.add(STRIP_LOGS);
+        list.add(INTERACT_BLOCKS);
 
         return ImmutableList.copyOf(list);
     }

--- a/v1_18/src/main/java/me/aleksilassila/litematica/printer/v1_18/Printer.java
+++ b/v1_18/src/main/java/me/aleksilassila/litematica/printer/v1_18/Printer.java
@@ -57,7 +57,7 @@ public class Printer {
             boolean isCurrentlyLooking = ((BlockHitResult) player.raycast(20, 1, false)).getBlockPos().equals(position);
 
             for (Guide guide : guides) {
-                if (guide.canExecute(player)) {
+                if (guide.canExecute(player) && LitematicaMixinMod.INTERACT_BLOCKS.getBooleanValue()) {
                     System.out.println("Executing " + guide + " for " + state);
                     List<Action> actions = guide.execute(player);
                     actionHandler.addActions(actions.toArray(Action[]::new));

--- a/v1_19/src/main/java/me/aleksilassila/litematica/printer/v1_19/LitematicaMixinMod.java
+++ b/v1_19/src/main/java/me/aleksilassila/litematica/printer/v1_19/LitematicaMixinMod.java
@@ -26,6 +26,7 @@ public class LitematicaMixinMod implements ModInitializer {
     public static final ConfigBoolean PRINT_MODE = new ConfigBoolean("printingMode", false, "Autobuild / print loaded selection.\nBe aware that some servers and anticheat plugins do not allow printing.");
     public static final ConfigBoolean REPLACE_FLUIDS_SOURCE_BLOCKS = new ConfigBoolean("replaceFluidSourceBlocks", true, "Whether or not fluid source blocks should be replaced by the printer.");
     public static final ConfigBoolean STRIP_LOGS = new ConfigBoolean("stripLogs", true, "Whether or not the printer should use normal logs if stripped\nversions are not available and then strip them with an axe.");
+    public static final ConfigBoolean INTERACT_BLOCKS = new ConfigBoolean("interactBlocks", true, "Whether or not the printer should set block states.");
 
     public static ImmutableList<IConfigBase> getConfigList() {
         List<IConfigBase> list = new java.util.ArrayList<>(Configs.Generic.OPTIONS);
@@ -35,6 +36,7 @@ public class LitematicaMixinMod implements ModInitializer {
 //        list.add(PRINT_IN_AIR);
         list.add(REPLACE_FLUIDS_SOURCE_BLOCKS);
         list.add(STRIP_LOGS);
+        list.add(INTERACT_BLOCKS);
 
         return ImmutableList.copyOf(list);
     }

--- a/v1_19/src/main/java/me/aleksilassila/litematica/printer/v1_19/Printer.java
+++ b/v1_19/src/main/java/me/aleksilassila/litematica/printer/v1_19/Printer.java
@@ -57,7 +57,7 @@ public class Printer {
             boolean isCurrentlyLooking = ((BlockHitResult) player.raycast(20, 1, false)).getBlockPos().equals(position);
 
             for (Guide guide : guides) {
-                if (guide.canExecute(player)) {
+                if (guide.canExecute(player) && LitematicaMixinMod.INTERACT_BLOCKS.getBooleanValue()) {
                     System.out.println("Executing " + guide + " for " + state);
                     List<Action> actions = guide.execute(player);
                     actionHandler.addActions(actions.toArray(Action[]::new));

--- a/v1_19_3/src/main/java/me/aleksilassila/litematica/printer/v1_19_3/LitematicaMixinMod.java
+++ b/v1_19_3/src/main/java/me/aleksilassila/litematica/printer/v1_19_3/LitematicaMixinMod.java
@@ -26,6 +26,7 @@ public class LitematicaMixinMod implements ModInitializer {
     public static final ConfigBoolean PRINT_MODE = new ConfigBoolean("printingMode", false, "Autobuild / print loaded selection.\nBe aware that some servers and anticheat plugins do not allow printing.");
     public static final ConfigBoolean REPLACE_FLUIDS_SOURCE_BLOCKS = new ConfigBoolean("replaceFluidSourceBlocks", true, "Whether or not fluid source blocks should be replaced by the printer.");
     public static final ConfigBoolean STRIP_LOGS = new ConfigBoolean("stripLogs", true, "Whether or not the printer should use normal logs if stripped\nversions are not available and then strip them with an axe.");
+    public static final ConfigBoolean INTERACT_BLOCKS = new ConfigBoolean("interactBlocks", true, "Whether or not the printer should set block states.");
 
     public static ImmutableList<IConfigBase> getConfigList() {
         List<IConfigBase> list = new java.util.ArrayList<>(Configs.Generic.OPTIONS);
@@ -35,6 +36,7 @@ public class LitematicaMixinMod implements ModInitializer {
 //        list.add(PRINT_IN_AIR);
         list.add(REPLACE_FLUIDS_SOURCE_BLOCKS);
         list.add(STRIP_LOGS);
+        list.add(INTERACT_BLOCKS);
 
         return ImmutableList.copyOf(list);
     }

--- a/v1_19_3/src/main/java/me/aleksilassila/litematica/printer/v1_19_3/Printer.java
+++ b/v1_19_3/src/main/java/me/aleksilassila/litematica/printer/v1_19_3/Printer.java
@@ -62,7 +62,7 @@ public class Printer {
             boolean isCurrentlyLookingSchematic = result != null && result.getBlockPos().equals(position);
 
             for (Guide guide : guides) {
-                if (guide.canExecute(player)) {
+                if (guide.canExecute(player) && LitematicaMixinMod.INTERACT_BLOCKS.getBooleanValue()) {
                     System.out.println("Executing " + guide + " for " + state);
                     List<Action> actions = guide.execute(player);
                     actionHandler.addActions(actions.toArray(Action[]::new));


### PR DESCRIPTION
When building notebot chamber for example, you don't need to set every single noteblock state. Notebot will retune all the blocks anyway so this only kills time. This option will also work for other block states if someone has different reason to disable it.